### PR TITLE
add dotenv enviroment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 build/
 tmp/
 temp/
+.env

--- a/data-source.ts
+++ b/data-source.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata';
 import { DataSource } from 'typeorm';
-require('dotenv').config()
+import 'dotenv/config'
 export const AppDataSource = new DataSource({
   type: process.env.DB_DRIVER,
   host: process.env.DB_HOST,

--- a/data-source.ts
+++ b/data-source.ts
@@ -1,13 +1,13 @@
 import 'reflect-metadata';
 import { DataSource } from 'typeorm';
-
+require('dotenv').config()
 export const AppDataSource = new DataSource({
-  type: 'mysql',
-  host: 'localhost',
+  type: process.env.DB_DRIVER,
+  host: process.env.DB_HOST,
   port: 3306,
-  username: 'mesita',
-  password: 'mesita',
-  database: 'mesita',
+  username: process.env.DB_NAME,
+  password: process.env.DB_PASSWORD,
+  database: process.env.DB_NAME,
   synchronize: true,
   logging: false,
   entities: ['./src/models/*.{js,ts}'],

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "mariadb": "^3.0.0",
     "reflect-metadata": "^0.1.13",
     "typeorm": "0.3.6",
-    "mysql": "^2.14.1"
+    "mysql": "^2.14.1",
+    "dotenv": "^16.0.1"
   },
   "devDependencies": {
     "@types/express": "^4.17.13",


### PR DESCRIPTION
Se agrego ciegamente una nueva mejora para proteger los datos de conexion.
Pd: los archivos .env no deben subirse al repositorio, deben excluirse via gitignore, pero en este proyecto ya se subio sin excluir el archivo, se recomienda eliminar los commit anteriores o eliminar y volver a subir el repositorio con el .env excluido ya que git guarda todos los registros del repositorio y se puede acceder a un commit anterior y obtener los valores del .env